### PR TITLE
Merge mypy configs and get result passing

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,0 @@
-[mypy]
-
-disallow_untyped_defs = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ ignore = W503,W504
 
 
 [mypy]
+disallow_untyped_defs = True
 ignore_missing_imports = true
 warn_unreachable = true
 warn_unused_ignores = true

--- a/src/globus_sdk/exc/api.py
+++ b/src/globus_sdk/exc/api.py
@@ -42,7 +42,7 @@ class GlobusAPIError(GlobusError):
         )
 
     @property
-    def raw_json(self) -> Union[dict, None]:
+    def raw_json(self) -> Optional[Dict[str, Any]]:
         """
         Get the verbatim error message received from a Globus API, interpreted
         as JSON data
@@ -54,7 +54,9 @@ class GlobusAPIError(GlobusError):
             return None
 
         try:
-            return r.json()
+            # technically, this could be a non-dict JSON type, like a list or string
+            # but in those cases the user can just cast -- the "normal" case is a dict
+            return cast(Dict[str, Any], r.json())
         except ValueError:
             log.error(
                 "Error body could not be JSON decoded! "
@@ -80,7 +82,7 @@ class GlobusAPIError(GlobusError):
         if self._info is None:
             rawjson = self.raw_json
             json_data = rawjson if isinstance(rawjson, dict) else None
-            self._info = ErrorInfoContainer(cast(Optional[Dict[str, Any]], json_data))
+            self._info = ErrorInfoContainer(json_data)
         return self._info
 
     def _get_request_authorization_scheme(self) -> Union[str, None]:

--- a/src/globus_sdk/paging/last_key.py
+++ b/src/globus_sdk/paging/last_key.py
@@ -20,7 +20,7 @@ class LastKeyPaginator(Paginator):
             client_args=client_args,
             client_kwargs=client_kwargs,
         )
-        self.last_key = None
+        self.last_key: Optional[str] = None
 
     def pages(self) -> Iterator[GlobusHTTPResponse]:
         has_next_page = True

--- a/src/globus_sdk/paging/marker.py
+++ b/src/globus_sdk/paging/marker.py
@@ -27,7 +27,7 @@ class MarkerPaginator(Paginator):
             client_args=client_args,
             client_kwargs=client_kwargs,
         )
-        self.marker = None
+        self.marker: Optional[str] = None
 
     def pages(self) -> Iterator[GlobusHTTPResponse]:
         has_next_page = True

--- a/src/globus_sdk/paging/next_token.py
+++ b/src/globus_sdk/paging/next_token.py
@@ -28,7 +28,7 @@ class NextTokenPaginator(Paginator):
             client_args=client_args,
             client_kwargs=client_kwargs,
         )
-        self.next_token = None
+        self.next_token: Optional[str] = None
 
     def pages(self) -> Iterator[GlobusHTTPResponse]:
         has_next_page = True

--- a/src/globus_sdk/services/auth/client_types/base.py
+++ b/src/globus_sdk/services/auth/client_types/base.py
@@ -134,7 +134,7 @@ class AuthClient(client.BaseClient):
         in the API documentation for details.
         """
 
-        def _convert_listarg(val: Union[List[ToStr], ToStr]) -> str:
+        def _convert_listarg(val: Union[List[ToStr], ToStr, str]) -> str:
             if isinstance(val, collections.abc.Iterable) and not isinstance(val, str):
                 return ",".join(utils.safe_stringify(x) for x in val)
             else:
@@ -492,7 +492,7 @@ class AuthClient(client.BaseClient):
         jwk_data = self.get(jwks_uri).data
         if not as_pem:
             log.debug("returning jwk data where as_pem=False")
-            return jwk_data
+            return cast(dict, jwk_data)
         else:
             log.debug("JWK as_pem=True requested, decoding...")
             # decode from JWK to an RSA PEM key for JWT decoding

--- a/src/globus_sdk/services/auth/token_response.py
+++ b/src/globus_sdk/services/auth/token_response.py
@@ -82,7 +82,7 @@ class _ByScopesGetter:
                 )
             )
         # pop the only element in the set
-        return toks.pop()
+        return cast(Dict[str, Union[str, int]], toks.pop())
 
     def __contains__(self, item: str) -> bool:
         """

--- a/src/globus_sdk/services/search/data.py
+++ b/src/globus_sdk/services/search/data.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from globus_sdk import utils
 
@@ -63,11 +63,15 @@ class SearchQuery(utils.PayloadWrapper):
         size: Optional[int] = None,
         date_interval: Optional[str] = None,
         histogram_range: Optional[Tuple[Any, Any]] = None,
-        **kwargs: Any
+        additional_fields: Optional[Dict[str, Any]] = None,
     ) -> "SearchQuery":
         self["facets"] = self.get("facets", [])
-        facet: Dict[str, Any] = {"name": name, "field_name": field_name, "type": type}
-        facet.update(kwargs)
+        facet: Dict[str, Any] = {
+            "name": name,
+            "field_name": field_name,
+            "type": type,
+            **(additional_fields or {}),
+        }
         if size is not None:
             facet["size"] = size
         if date_interval is not None:
@@ -78,30 +82,46 @@ class SearchQuery(utils.PayloadWrapper):
         self["facets"].append(facet)
         return self
 
-    # TODO: type signature
     def add_filter(
-        self, field_name: str, values, type: str = "match_all", **kwargs: Any
+        self,
+        field_name: str,
+        values: List[str],
+        type: str = "match_all",
+        additional_fields: Optional[Dict[str, Any]] = None,
     ) -> "SearchQuery":
         self["filters"] = self.get("filters", [])
-        new_filter = {"field_name": field_name, "values": values, "type": type}
-        new_filter.update(kwargs)
+        new_filter = {
+            "field_name": field_name,
+            "values": values,
+            "type": type,
+            **(additional_fields or {}),
+        }
         self["filters"].append(new_filter)
         return self
 
-    # TODO: type signature
-    def add_boost(self, field_name: str, factor, **kwargs: Any) -> "SearchQuery":
+    def add_boost(
+        self,
+        field_name: str,
+        factor: Union[str, int, float],
+        additional_fields: Optional[Dict[str, Any]] = None,
+    ) -> "SearchQuery":
         self["boosts"] = self.get("boosts", [])
-        boost = {"field_name": field_name, "factor": factor}
-        boost.update(kwargs)
+        boost = {
+            "field_name": field_name,
+            "factor": factor,
+            **(additional_fields or {}),
+        }
         self["boosts"].append(boost)
         return self
 
     def add_sort(
-        self, field_name: str, order: Optional[str] = None, **kwargs: Any
+        self,
+        field_name: str,
+        order: Optional[str] = None,
+        additional_fields: Optional[Dict[str, Any]] = None,
     ) -> "SearchQuery":
         self["sort"] = self.get("sort", [])
-        sort = {"field_name": field_name}
-        sort.update(kwargs)
+        sort = {"field_name": field_name, **(additional_fields or {})}
         if order is not None:
             sort["order"] = order
         self["sort"].append(sort)


### PR DESCRIPTION
- New annotations on SearchQuery helper object
- Handle cases where we are returning Any with casts
- Annotate Optional[str] fields on paginator attrs so that warn-unreachable isn't triggered

---

I am wondering, as this made me touch `GlobusHTTPResponse.raw_json`, whether or not we should have `raw_json: Any` and `json_dict: Dict[str, Any]` or something like that. The reason being that there are some APIs out there which return raw array responses. (I think that's bad design, but that's a whole other topic.)
For now, casting is fine.